### PR TITLE
[HotFix] Bill Summary formatting changes

### DIFF
--- a/lib/css/bill.css
+++ b/lib/css/bill.css
@@ -62,6 +62,10 @@ table.nurego-table td {
   display: none;
 }
 
+.bill-summary .item a:hover {
+  color: #ea622c;
+}
+
 .bill-summary span.left {
   float: left;
 }
@@ -71,8 +75,8 @@ table.nurego-table td {
 }
 
 .bill-summary .title {
-  font-weight: normal;
-  font-size: 0.857em;
+  font-weight: bold;
+  font-size: 1.2em;
   color: #9799a2;
   line-height: 2em;
   border-bottom: solid 1px #dfe1e6;

--- a/lib/html/bill.html
+++ b/lib/html/bill.html
@@ -2,7 +2,7 @@
   <!-- Bill Summary -->
   <div cap-info="" class="bill-summary" id="bill-summary">
     <div class="title">
-      BILLING SUMMARY
+      SUMMARY
     </div>
     <br/>
     <div class="item" id="nr-statement-date">
@@ -25,7 +25,7 @@
     <div class="item" id="nr-last-payment">
       <span class="left">Last Payment:</span>
       <div>
-        <span class="left" id="amount" style="margin-left: 140px;">$50</span>
+        <span class="left" id="amount" style="margin-left: 154px;">$50</span>
         <span class="right" id="date">10-12-2014</span>
         <span class="right" id="link" style="margin-right: -160px;"><a href="/subscriptions/bill/">View Bill</a></span>
       </div>

--- a/lib/js/bill.js
+++ b/lib/js/bill.js
@@ -36,12 +36,12 @@
         statement_date.css('display', 'inline-block');
         billing_period.find("#value").html(moment(bill.period_start_time).format("MM/DD/YYYY") + " - " + moment(bill.period_end_time).format("MM/DD/YYYY"));
         billing_period.css('display', 'inline-block');
-        statement_amount.find("#value").html("$" + bill.total_owed);
+        statement_amount.find("#value").html("$" + Number(bill.total_owed).toFixed(2));
         statement_amount.css('display', 'inline-block').css('font-weight', 'bold');
         // If there was a previous bill, show price, date and link to bill
         if (previous_bill){
           last_payment.find("#date").html(moment(previous_bill.charge_date).format("MM/DD/YYYY"));
-          last_payment.find("#amount").html("$" + previous_bill.total_owed);
+          last_payment.find("#amount").html("$" + Number(previous_bill.total_owed).toFixed(2));
           previous_bill_link = last_payment.find("#link a");
           previous_bill_link.attr("href", previous_bill_link.attr("href") + previous_bill.id);
           last_payment.css('display', 'inline-block');
@@ -71,7 +71,7 @@
           else if (steps[i].step_type === "prorate"){
             // Display prorate price only if change value is not 0
             if (steps[i].price_before){
-              amount_before_proration.find("#value").html("$" + steps[i].price_before);
+              amount_before_proration.find("#value").html("$" + Number(steps[i].price_before).toFixed(2));
               amount_before_proration.css('display', 'inline-block');
             }
           }
@@ -93,7 +93,7 @@
             var tr_recurring = recurring_tr_tmpl.clone().html("");
             var td_price = price_tmpl.clone();
 
-            td_price.html("$" + base_price[i].change);
+            td_price.html("$" + Number(base_price[i].change).toFixed(2));
             td_price.show();
             tr_recurring.append(td_price);
 
@@ -130,7 +130,7 @@
             // Decide whether to display price or percentage for discount/trial
             if (discount_items[i].discount.price && discount_items[i].discount.price !== 0){
               tbody.find("th:nth-child(3)").html("Price"); // Replace % with price title
-              td_price_percentage.html("$" + discount_items[i].discount.price);
+              td_price_percentage.html("$" + Number(discount_items[i].discount.price).toFixed(2));
             } 
             else {
               td_price_percentage.html(discount_items[i].discount.percent);
@@ -139,7 +139,7 @@
             tr_discount.append(td_price_percentage);
 
 
-            td_amount.html("$" + discount_items[i].change);
+            td_amount.html("$" + Number(discount_items[i].change).toFixed(2));
             td_amount.show();
             tr_discount.append(td_amount);
 
@@ -173,10 +173,10 @@
             td_unit.show();
             tr_feature.append(td_unit);
             unit_price = tiered_items[i].feature.price_per_unit === null ? 0 : tiered_items[i].feature.price_per_unit;
-            td_unit_price.html("$" + unit_price);
+            td_unit_price.html("$" + Number(unit_price).toFixed(2));
             td_unit_price.show();
             tr_feature.append(td_unit_price);
-            td_price.html("$" + tiered_items[i].change);
+            td_price.html("$" + Number(tiered_items[i].change).toFixed(2));
             td_price.show();
             tr_feature.append(td_price);
 

--- a/lib/js/bills.js
+++ b/lib/js/bills.js
@@ -37,7 +37,7 @@
           td_bill_period.find("span a").attr("href", Nurego.p.bill_url + bills[i].id);
           td_bill_period.show();
           tr_bill.append(td_bill_period);
-          td_bill_total.html("$" + bills[i].total_owed);
+          td_bill_total.html("$" + Number(bills[i].total_owed).toFixed(2));
           td_bill_total.show();
           tr_bill.append(td_bill_total);
           td_bill_status.html(bills[i].charge_state);


### PR DESCRIPTION
Format all price amounts to have 2 digits after the period
Change bill summary title and make it bigger
Set View Bill link hover color (to be consistent with all other links)
Fix last payment aligment to be at the same position as Billing Period
