### PR TITLE
Add zero_price_alt feature for simple_3_tier

### DIFF
--- a/lib/js/nurego.js
+++ b/lib/js/nurego.js
@@ -163,6 +163,7 @@ var timeout_func,
         customer_id: '',
         customer_plan_render: this.Nurego.customerPlan.OFFERINGS_ONLY,
         zero_price_alt: 'Pay as You Go',
+        zero_price_simple_tier_alt: 'Free',
         plan_description: '',
         display_cent_symbol: true,
         sign_up_button_text: 'Sign Up'

--- a/lib/js/simple_3_tier.js
+++ b/lib/js/simple_3_tier.js
@@ -156,7 +156,7 @@
             td_price.html(Nurego.p.label_before_price + plan_price + Nurego.p.label_after_price +
             '<span class="nr-price-period">/' + plans[i].period.replace("ly", "") + '</span>');
           } else {
-            td_price.html(Nurego.p.zero_price_alt);
+            td_price.html(Nurego.p.zero_price_simple_tier_alt);
             td_price.css('color', 'black');
           }
           td_price.show();


### PR DESCRIPTION
Note that if price for a plan is $0.00, the following default alt. text will be displayed: "Pay As You Go", unless the param "zero_price_alt" is overridden.
